### PR TITLE
feat: 🎸 aarch64-linux を Gemfile.lock に追加した

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,10 +97,12 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.0.3)
+    mini_portile2 (2.5.1)
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.7)
-    nokogiri (1.11.4-x86_64-darwin)
+    nokogiri (1.11.4)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     nokogiri (1.11.4-x86_64-linux)
       racc (~> 1.4)
@@ -213,7 +215,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-20
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
- darwin が消えてしまった……
- デプロイ先は aarch64 なので、とりあえずこっちを優先